### PR TITLE
Alert user to non-existent vote listener directory instead of throwing runtime exception

### DIFF
--- a/java/com/vexsoftware/votifier/model/ListenerLoader.java
+++ b/java/com/vexsoftware/votifier/model/ListenerLoader.java
@@ -26,6 +26,14 @@ public class ListenerLoader {
 	List<VoteListener> listeners = new ArrayList<VoteListener>();
 	File dir = new File(directory);
 
+	// Verify configured vote listener directory exists
+	if (!dir.exists()) {
+	    LOG.log(Level.WARNING,
+		    "No listeners loaded! Cannot find listener directory '"
+			    + dir + "' ");
+	    return listeners;
+	}
+
 	// Load the vote listener instances.
 	ClassLoader loader;
 	try {


### PR DESCRIPTION
Blake:

I'm glad I was able to meet your needs. The first dance is always the hardest. I happened to notice a few posts about missing vote listener directories. I've addressed that issue in this patch. It verifies the listener directory's existence. If not found, users are warned and no vote listeners are loaded. Votifier continues to run in a degraded state, receiving votes and generating corresponding VotifierEvent events.

The patch is optional. I'll leave it up to you if you want to apply the patch or squirrel it away for the next major release.

Best,

Frelling
