### PR TITLE
Performance improvements

### DIFF
--- a/src/main/java/com/vexsoftware/votifier/net/VoteReceiver.java
+++ b/src/main/java/com/vexsoftware/votifier/net/VoteReceiver.java
@@ -68,7 +68,7 @@ public class VoteReceiver extends Thread {
 	 */
 	public VoteReceiver(final Votifier plugin, String host, int port)
 			throws Exception {
-		super("Votifier network thread");
+		super("Votifier I/O");
 
 		this.plugin = plugin;
 		this.host = host;


### PR DESCRIPTION
By setting network thread priority low, decoding RSA-encrypted messages should not affect server performance.

Also I've modified it to use the "plugin" instance given in thread's constructor rather than the Votifier.getInstance method.
