### PR TITLE
Limit usernames to 16 characters.

### DIFF
--- a/src/main/java/com/vexsoftware/votifier/model/Vote.java
+++ b/src/main/java/com/vexsoftware/votifier/model/Vote.java
@@ -69,7 +69,7 @@ public class Vote {
 	 *            The new username
 	 */
 	public void setUsername(String username) {
-		this.username = username;
+		this.username = username.length() <= 16 ? username : username.substring(0, 16);
 	}
 
 	/**


### PR DESCRIPTION
Minecraft usernames are limites to 16 characters. However many voting sites allow for longer names. This provides plenty of space for offensive usernames. This is totally unnecessary, and can be cut off.
