### PR TITLE
Use proper try-with-resources for resources to prevent DoS attacks

### DIFF
--- a/src/main/java/com/vexsoftware/votifier/crypto/RSAIO.java
+++ b/src/main/java/com/vexsoftware/votifier/crypto/RSAIO.java
@@ -54,18 +54,18 @@ public class RSAIO {
 		// Store the public key.
 		X509EncodedKeySpec publicSpec = new X509EncodedKeySpec(
 				publicKey.getEncoded());
-		FileOutputStream out = new FileOutputStream(directory + "/public.key");
-		out.write(DatatypeConverter.printBase64Binary(publicSpec.getEncoded())
-				.getBytes());
-		out.close();
+		try (FileOutputStream out = new FileOutputStream(directory + "/public.key")) {
+			out.write(DatatypeConverter.printBase64Binary(publicSpec.getEncoded())
+					.getBytes());
+		}
 
 		// Store the private key.
 		PKCS8EncodedKeySpec privateSpec = new PKCS8EncodedKeySpec(
 				privateKey.getEncoded());
-		out = new FileOutputStream(directory + "/private.key");
-		out.write(DatatypeConverter.printBase64Binary(privateSpec.getEncoded())
-				.getBytes());
-		out.close();
+		try (FileOutputStream out = new FileOutputStream(directory + "/private.key")) {
+			out.write(DatatypeConverter.printBase64Binary(privateSpec.getEncoded())
+					.getBytes());
+		}
 	}
 
 	/**
@@ -81,21 +81,23 @@ public class RSAIO {
 	public static KeyPair load(File directory) throws Exception {
 		// Read the public key file.
 		File publicKeyFile = new File(directory + "/public.key");
-		FileInputStream in = new FileInputStream(directory + "/public.key");
-		byte[] encodedPublicKey = new byte[(int) publicKeyFile.length()];
-		in.read(encodedPublicKey);
-		encodedPublicKey = DatatypeConverter.parseBase64Binary(new String(
-				encodedPublicKey));
-		in.close();
+		byte[] encodedPublicKey;
+		try (FileInputStream in = new FileInputStream(publicKeyFile)) {
+			encodedPublicKey = new byte[(int) publicKeyFile.length()];
+			in.read(encodedPublicKey);
+			encodedPublicKey = DatatypeConverter.parseBase64Binary(new String(
+					encodedPublicKey));
+		}
 
 		// Read the private key file.
 		File privateKeyFile = new File(directory + "/private.key");
-		in = new FileInputStream(directory + "/private.key");
-		byte[] encodedPrivateKey = new byte[(int) privateKeyFile.length()];
-		in.read(encodedPrivateKey);
-		encodedPrivateKey = DatatypeConverter.parseBase64Binary(new String(
-				encodedPrivateKey));
-		in.close();
+		byte[] encodedPrivateKey;
+		try (FileInputStream in = new FileInputStream(privateKeyFile)) {
+			encodedPrivateKey = new byte[(int) privateKeyFile.length()];
+			in.read(encodedPrivateKey);
+			encodedPrivateKey = DatatypeConverter.parseBase64Binary(new String(
+					encodedPrivateKey));
+		}
 
 		// Instantiate and return the key pair.
 		KeyFactory keyFactory = KeyFactory.getInstance("RSA");

--- a/src/main/java/com/vexsoftware/votifier/net/VoteReceiver.java
+++ b/src/main/java/com/vexsoftware/votifier/net/VoteReceiver.java
@@ -110,8 +110,7 @@ public class VoteReceiver extends Thread {
 
 		// Main loop.
 		while (running) {
-			try {
-				Socket socket = server.accept();
+			try (Socket socket = server.accept()) {
 				socket.setSoTimeout(5000); // Don't hang on slow connections.
 				BufferedWriter writer = new BufferedWriter(
 						new OutputStreamWriter(socket.getOutputStream()));


### PR DESCRIPTION
The current version of the code doesn't close its resources in case of errors. If this happens to many times, the server will crash because "to many open files". This is a Denial of Service attack vector as clients can trigger his condition by sending bogus data to Votifer's listening port.
