### PR TITLE
Update maven-jar-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>2.3.2</version>
             </plugin>
             <plugin>
                 <groupId>com.google.code.maven-replacer-plugin</groupId>


### PR DESCRIPTION
The configured version of maven-jar-plugin has a problem reading long numeric identifiers:

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-jar-plugin:2.3.1:jar (default-jar) on project votifier: Error assembling JAR: Failed to read filesystem attributes for: /var/lib/jenkins/workspace/Votifier/pom.xml: Failed to retrieve numeric file attributes using: '/bin/sh -c ls -1nlad /var/lib/jenkins/workspace/Votifier/pom.xml': Error inside systemOut parser: For input string: "4294967294" -> [Help 1]

Updating to 2.3.2 fixes the problem.