### PR TITLE
Changed repo url and added javax.xml.bind to dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,10 +9,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
-    <repositories>
+   <repositories>
         <repository>
-            <id>bukkit</id>
-            <url>http://repo.bukkit.org/content/groups/public/</url>
+          <id>elmakers-repo</id>
+          <url>http://maven.elmakers.com/repository/</url>
         </repository>
     </repositories>
     
@@ -24,6 +24,11 @@
             <version>1.7.9-R0.2</version>
             <type>jar</type>
             <scope>compile</scope>
+        </dependency>
+		<dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.4.0-b180830.0359</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
    <repositories>
         <repository>
           <id>elmakers-repo</id>
-          <url>http://maven.elmakers.com/repository/</url>
+          <url>https://maven.elmakers.com/repository/</url>
         </repository>
     </repositories>
     


### PR DESCRIPTION
Changed repo url because old one was dmca'ed
added javax.xml.bind because since jdk 11, javax.xml.bind was removed from jdk